### PR TITLE
Fix top_p null still sent in API requests after #385

### DIFF
--- a/openevolve/llm/openai.py
+++ b/openevolve/llm/openai.py
@@ -155,9 +155,11 @@ class OpenAILLM(LLMInterface):
                 "model": self.model,
                 "messages": formatted_messages,
                 "temperature": kwargs.get("temperature", self.temperature),
-                "top_p": kwargs.get("top_p", self.top_p),
                 "max_tokens": kwargs.get("max_tokens", self.max_tokens),
             }
+            top_p = kwargs.get("top_p", self.top_p)
+            if top_p is not None:
+                params["top_p"] = top_p
 
             # Handle reasoning_effort for open source reasoning models.
             reasoning_effort = kwargs.get("reasoning_effort", self.reasoning_effort)


### PR DESCRIPTION
## Summary

PR #385 (closing #378) made `top_p` optional and defaulted it to `None` in `LLMConfig`, but the API call layer in `openevolve/llm/openai.py` still unconditionally includes `top_p` in the request params:

```python
params = {
    ...
    "top_p": kwargs.get("top_p", self.top_p),  # sends None when top_p is unset
    ...
}
```

This puts `"top_p": None` into the params dict. Providers like **AWS Bedrock**, **LiteLLM**, and other OpenAI-compatible wrappers may serialize it as `"top_p": null` in the JSON body, triggering a 400 error.

**Fix:** Only include `top_p` in params when it is explicitly set (not `None`).

## Changes

- `openevolve/llm/openai.py`: Conditionally include `top_p` in request params only when not `None`

## Test plan

- [x] All 368 tests pass
- [x] No new config-level changes needed (handled by #385)

Fixes #414