### PR TITLE
fix(process-pool): bound shutdown latency

### DIFF
--- a/openevolve/process_parallel.py
+++ b/openevolve/process_parallel.py
@@ -332,6 +332,61 @@ def _run_iteration_worker(
         return SerializableResult(error=str(e), iteration=iteration)
 
 
+def _wait_for_processes(processes: tuple[mp.Process, ...], timeout: float) -> list[mp.Process]:
+    """Wait for process handles to observe worker exits without blocking indefinitely."""
+    deadline = time.monotonic() + timeout
+    alive = list(processes)
+    while alive:
+        next_alive = []
+        for process in alive:
+            try:
+                process.join(timeout=0)
+                if process.is_alive():
+                    next_alive.append(process)
+            except (AssertionError, ValueError):
+                continue
+        alive = next_alive
+        remaining = deadline - time.monotonic()
+        if not alive or remaining <= 0:
+            break
+        time.sleep(min(0.001, remaining))
+    return alive
+
+
+def _terminate_process_pool(executor: ProcessPoolExecutor) -> None:
+    """Cancel queued work and ensure all process-pool workers have exited."""
+    # Python < 3.14 has no public force-shutdown API. Capture only this
+    # executor's workers before shutdown clears its private process mapping.
+    process_map = getattr(executor, "_processes", None) or {}
+    processes = tuple(process_map.copy().values())
+    terminate_workers = getattr(executor, "terminate_workers", None)
+
+    if callable(terminate_workers):
+        terminate_workers()
+    else:
+        executor.shutdown(wait=False, cancel_futures=True)
+        for process in processes:
+            try:
+                if process.is_alive():
+                    process.terminate()
+            except (ProcessLookupError, ValueError):
+                continue
+
+    surviving_processes = _wait_for_processes(processes, timeout=1.0)
+    for process in surviving_processes:
+        try:
+            process.kill()
+        except (ProcessLookupError, ValueError):
+            continue
+
+    surviving_processes = _wait_for_processes(tuple(surviving_processes), timeout=1.0)
+    if surviving_processes:
+        logger.warning(
+            "Process-pool workers did not exit: %s",
+            [process.pid for process in surviving_processes],
+        )
+
+
 class ProcessParallelController:
     """Controller for process-based parallel evolution"""
 
@@ -428,9 +483,10 @@ class ProcessParallelController:
         """Stop the process pool"""
         self.shutdown_event.set()
 
-        if self.executor:
-            self.executor.shutdown(wait=True)
-            self.executor = None
+        executor = self.executor
+        self.executor = None
+        if executor:
+            _terminate_process_pool(executor)
 
         logger.info("Stopped process pool")
 

--- a/tests/test_process_parallel.py
+++ b/tests/test_process_parallel.py
@@ -4,17 +4,26 @@ Tests for process-based parallel controller
 
 import asyncio
 import os
+from pathlib import Path
 import tempfile
 import unittest
 from unittest.mock import Mock, patch, MagicMock
 import time
-from concurrent.futures import Future
+from concurrent.futures import Future, ProcessPoolExecutor
+
+
+def _slow_test_worker(marker_path: str) -> str:
+    Path(marker_path).write_text(str(os.getpid()))
+    time.sleep(5)
+    return "finished"
+
 
 # Set dummy API key for testing
 os.environ["OPENAI_API_KEY"] = "test"
 
 from openevolve.config import Config, DatabaseConfig, EvaluatorConfig, LLMConfig, PromptConfig
 from openevolve.database import Program, ProgramDatabase
+from openevolve import process_parallel as process_parallel_module
 from openevolve.process_parallel import ProcessParallelController, SerializableResult
 
 
@@ -85,6 +94,55 @@ def evaluate(program_path):
         controller.stop()
         self.assertIsNone(controller.executor)
         self.assertTrue(controller.shutdown_event.is_set())
+
+    def test_controller_stop_terminates_running_workers(self):
+        """Stopping the controller does not wait for stuck process-pool work."""
+        controller = ProcessParallelController(self.config, self.eval_file, self.database)
+        executor = ProcessPoolExecutor(max_workers=1)
+        controller.executor = executor
+        marker_path = os.path.join(self.test_dir, "worker.pid")
+        future = executor.submit(_slow_test_worker, marker_path)
+
+        deadline = time.monotonic() + 5
+        while not os.path.exists(marker_path) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(os.path.exists(marker_path))
+        worker_pid = int(Path(marker_path).read_text())
+
+        started = time.monotonic()
+        controller.stop()
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 1)
+        self.assertIsNone(controller.executor)
+        self.assertTrue(controller.shutdown_event.is_set())
+        deadline = time.monotonic() + 1
+        while not future.done() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(future.done())
+        with self.assertRaises(ProcessLookupError):
+            os.kill(worker_pid, 0)
+
+        # Cleanup is idempotent after the executor reference is cleared.
+        controller.stop()
+
+    def test_process_pool_shutdown_escalates_to_kill(self):
+        """Workers still alive after terminate are killed before returning."""
+        process = Mock()
+        process.is_alive.return_value = True
+        executor = Mock(spec=["_processes", "shutdown"])
+        executor._processes = {123: process}
+
+        with patch.object(
+            process_parallel_module,
+            "_wait_for_processes",
+            side_effect=[[process], []],
+        ):
+            process_parallel_module._terminate_process_pool(executor)
+
+        executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
+        process.terminate.assert_called_once_with()
+        process.kill.assert_called_once_with()
 
     def test_database_snapshot_creation(self):
         """Test creating database snapshot for workers"""


### PR DESCRIPTION
Fixes #297.

## Summary

- prevent ProcessParallelController.stop() from waiting indefinitely for running process-pool work
- use the public worker-termination API on Python 3.14 and a bounded compatibility path on Python 3.10-3.13
- cancel queued work, terminate running workers, and escalate survivors to kill() after a bounded wait
- add regression coverage for stuck workers, cleanup idempotence, and kill escalation

## Why

ProcessPoolExecutor future.cancel() cannot cancel a task that is already running. The existing shutdown(wait=True) therefore waits for that task to finish, which matches the 27+ second and multi-hour shutdown hangs reported in #297.

The new path captures only this executor's workers, requests immediate shutdown, waits for those processes to exit, and escalates only workers that survive termination. Unrelated processes are not touched.

## Performance

A strict scaled reproduction measures process_pool_shutdown_ms across multiple task durations with correctness gates for completed results, queued/running futures, worker cleanup, repeated stop(), post-return side effects, and unrelated processes.

| Variant | Metric |
| --- | ---: |
| Current main, Python 3.10 median | 1496.85 ms |
| Cleaned patch, Python 3.10 median | 3.62 ms |
| Cleaned patch, Python 3.14 median | 2.31 ms |

That is about a 99.76% reduction (about 414x) on the minimum supported Python version. A separate 30-second worker stopped in 3.48 ms with no live worker left behind. Idle-pool shutdown remained effectively unchanged (3.40 ms before, 3.58 ms after).

Supplementary autoresearch: [20-step public dashboard](https://dashboard.weco.ai/share/u0wVgi_6zZ9Kx_wfo_KQyNJDc0HAYZl9).

## Validation

- Python 3.10: python -m unittest discover tests (392 passed)
- Python 3.14: python -m unittest discover tests (392 passed)
- Python 3.10: focused process-parallel tests (8 passed)
- Python 3.14: focused process-parallel tests (8 passed)
- strict shutdown evaluator on Python 3.10 and Python 3.14
- Black on both touched files
- git diff --check
