### PR TITLE
Fix: propagate top-level `llm.provider` to per-model configs

### DIFF
--- a/openevolve/config.py
+++ b/openevolve/config.py
@@ -174,6 +174,7 @@ class LLMConfig(LLMModelConfig):
 
         # Update models with shared configuration values
         shared_config = {
+            "provider": self.provider,
             "api_base": self.api_base,
             "api_key": self.api_key,
             "temperature": self.temperature,
@@ -228,6 +229,7 @@ class LLMConfig(LLMModelConfig):
 
         # Update models with shared configuration values
         shared_config = {
+            "provider": self.provider,
             "api_base": self.api_base,
             "api_key": self.api_key,
             "temperature": self.temperature,

--- a/tests/test_claude_code_llm.py
+++ b/tests/test_claude_code_llm.py
@@ -133,6 +133,81 @@ class TestMaxBudgetConfig(unittest.TestCase):
         self.assertEqual(config.llm.models[0].max_budget_usd, 3.0)
 
 
+class TestProviderPropagation(unittest.TestCase):
+    """A top-level ``llm.provider`` must reach each model in the ensemble.
+
+    Regression test for a bug where ``provider`` was omitted from the shared
+    config propagated to per-model configs, so ``provider: "claude_code"`` set
+    at the ``llm:`` level was silently dropped and every model fell back to the
+    OpenAI backend (crashing with "Missing credentials").
+    """
+
+    def test_top_level_provider_propagates_to_models(self):
+        from openevolve.config import Config
+
+        config = Config.from_dict(
+            {
+                "llm": {
+                    "provider": "claude_code",
+                    "models": [
+                        {"name": "sonnet", "weight": 0.8},
+                        {"name": "haiku", "weight": 0.2},
+                    ],
+                }
+            }
+        )
+        self.assertTrue(config.llm.models, "expected models to be configured")
+        for model in config.llm.models:
+            self.assertEqual(model.provider, "claude_code")
+        # Evaluator models default to the evolution models and must inherit too.
+        for model in config.llm.evaluator_models:
+            self.assertEqual(model.provider, "claude_code")
+
+    def test_per_model_provider_overrides_top_level(self):
+        from openevolve.config import Config
+
+        config = Config.from_dict(
+            {
+                "llm": {
+                    "provider": "claude_code",
+                    "models": [
+                        {"name": "sonnet", "weight": 0.5},
+                        {"name": "gpt-4o", "weight": 0.5, "provider": "openai"},
+                    ],
+                }
+            }
+        )
+        providers = {m.name: m.provider for m in config.llm.models}
+        self.assertEqual(providers["sonnet"], "claude_code")
+        self.assertEqual(providers["gpt-4o"], "openai")
+
+    def test_default_provider_is_none(self):
+        from openevolve.config import Config
+
+        config = Config.from_dict(
+            {"llm": {"models": [{"name": "gpt-4o", "weight": 1.0}]}}
+        )
+        self.assertIsNone(config.llm.models[0].provider)
+
+    def test_ensemble_builds_claude_code_from_config(self):
+        from openevolve.config import Config
+        from openevolve.llm.ensemble import LLMEnsemble
+
+        config = Config.from_dict(
+            {
+                "llm": {
+                    "provider": "claude_code",
+                    "models": [{"name": "sonnet", "weight": 1.0}],
+                }
+            }
+        )
+        ensemble = LLMEnsemble(config.llm.models)
+        self.assertTrue(
+            all(isinstance(m, ClaudeCodeLLM) for m in ensemble.models),
+            "ensemble should build ClaudeCodeLLM instances from top-level provider",
+        )
+
+
 class TestProviderRegistry(unittest.TestCase):
     def test_claude_code_in_registry(self):
         from openevolve.llm.ensemble import _PROVIDER_REGISTRY


### PR DESCRIPTION
## Summary

A top-level `llm.provider` (e.g. `claude_code`) set in a config was silently dropped and never reached the individual models, so the ensemble always fell back to the OpenAI backend. This makes the `examples/claude_code_quickstart` example crash immediately with:

```
openai.OpenAIError: Missing credentials. Please pass an `api_key` ... or set the `OPENAI_API_KEY` ... environment variable.
```

even though `config.yaml` correctly sets `provider: "claude_code"`.

## Root cause

`LLMConfig` propagates shared settings down to each per-model `LLMModelConfig` via a `shared_config` dict (in both `__post_init__` and `rebuild_models`). That dict included `api_base`, `api_key`, `temperature`, etc. — but **not `provider`**. So each model kept `provider=None`, and `LLMEnsemble._create_model` routed it to `OpenAILLM` instead of `ClaudeCodeLLM`.

```python
>>> c = Config.from_yaml("examples/claude_code_quickstart/config.yaml")
>>> c.llm.provider
'claude_code'
>>> [m.provider for m in c.llm.models]
[None, None]          # <-- provider never propagated
```

## Fix

Add `"provider": self.provider` to both `shared_config` dicts. Propagation goes through `update_model_params(..., overwrite=False)`, so an explicit **per-model** `provider` still takes precedence over the top-level default.

## Tests

Added `TestProviderPropagation` to `tests/test_claude_code_llm.py`:

- top-level provider reaches every evolution **and** evaluator model,
- an explicit per-model provider overrides the top-level one,
- the default provider stays `None` (unchanged OpenAI-default behavior),
- `LLMEnsemble` built from such a config yields `ClaudeCodeLLM` instances end to end.

The three propagation tests fail on `main` (`None != 'claude_code'`) and pass with this change. Full suite: `417 passed` (unchanged), plus the new cases.

## How it was found

Running the documented `examples/claude_code_quickstart` example with the Claude Code CLI backend on Python 3.14. After the fix, a full 50-iteration run completed successfully, evolving the seed random-search into a simulated-annealing optimizer (`combined_score` 1.2148 → 1.4995).

